### PR TITLE
doc: added go install instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@
 eget dagimg-dot/gitsnip
 ```
 
+### Using Go
+
+```bash
+go install github.com/dagimg-dot/gitsnip/cmd/gitsnip@latest
+```
+
 ### Manual Installation
 
 #### Linux/macOS


### PR DESCRIPTION
this PR adds instructions for how to install via `go install` to the readme. This is generally the preferred way to install Go tools. 